### PR TITLE
2.0.0

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "singleQuote": true,
-  "jsxSingleQuote": true,
-  "semi": false,
+  "jsxSingleQuote": false,
+  "semi": true,
   "tabWidth": 2,
   "bracketSpacing": true,
   "arrowParens": "always",

--- a/README.md
+++ b/README.md
@@ -16,104 +16,16 @@ YARN:
 yarn add modal-relay
 ```
 
-## Usage
-Add the `<ModalRelay/>` to your app and pass your modal components. You can use the built in modal or pass your own. **Make sure you set the ID for each modal on the components that are being passed to the router.**
- 
-```tsx
-import React from 'react'
-import { ModalRelay, Modal, useModalStore } from 'modal-relay';
-
-const modalRoot = document.getElementById('modal-root');
-
-const App = () => {
-  const {activate, deactivate} = useModalStore();
-
-  return (
-    <div>
-      <button onClick={() => activate('settings')}>Edit Settings</button>
-      <ModalRelay modalRoot={modalRoot}>
-        <Modal
-          id="settings"
-          title="Settings"
-          actions={[
-            {
-              label: 'Close',
-              onClick: () => deactivate('settings')
-            }
-          ]}
-        >
-          <h1>Settings</h1>
-        </Modal>
-      </ModalRelay>
-    </div>
-  )
-}
-
-export default App
-```
-
-## Opening Modals From Anywhere
-You can open a modal from anywhere by using the `<ModalLink/>` component.
-
-```tsx
-import React from 'react';
-import { ModalLink } from 'modal-relay';
-
-// You can use any HTMLButtonElement props with the <ModalLink/> component.
-const buttonStyle = {backgroundColor: '#333', color: 'white', border: 'none', borderRadius: '5em', padding: '10px 10px', fontWeight: 'bold'}
-
-const SomePage = () => {
-    return (
-        <div>
-            <header>
-                <h1>Some Page</h1>
-            </header>
-            <main>
-                <section>
-                    <p>Some content</p>
-                    <ModalLink open="settings" style={buttonStyle}>
-                        Edit Settings
-                    </ModalLink>
-                </section>
-            </main>
-        </div>
-    );
-}
-
-export default SomePage;
-```
-
-## Common Mistakes
-There are two ways that you could mess this up right out of the box.
-
-1. You didn't create a portal element:
-  - You'll need access to the HTML markup where your React app is being rendered. If you're using something like Create React App that will be the `index.html` located within your `./public` folder. If you're not using CRA you will likely have to figure out how to modify the HTML template created by your build system. Most frameworks provide documentation about how to do this but if you're confused just open an issue! :)
-2. No ID Set At Modal Router Level:
-  - I think this is better to show an example of what works and what doesn't:
-
-##### Works
-```tsx
-<ModalRelay modalRoot={modalRoot}>
-  <YourCustomModal id="custom-modal-one"/>
-  <YourOtherModal id="other-modal"/>
-</ModalRelay>
-```
-
-##### Doesn't Work
-```tsx
-<ModalRelay modalRoot={modalRoot}>
-  <YourCustomModal/>
-  <YourOtherModal/>
-</ModalRelay>
-```
-Even if you pass an ID to the `<Modal/>` component within your custom modal, the `<ModalRelay/>` won't be able to detect it. A good rule of thumb is to create your ID as a variable and export it from your custom modal. Then when you want to activate that modal you just import that variable and pass it to `activate()` or `<ModalLink/>`.
+## Examples
+[Full Example](https://github.com/freddiemixell/modal-relay/tree/main/example/)
 
 ## API
 Docs for each component are co-located with the components. Check out the `/src` directory for the most accurate listing of components/core functionality and documentation. I'm going to try to keep a list updated here but it may be out of sync at times.
 
 #### [<Modal\/>](https://github.com/freddiemixell/modal-relay/tree/main/src/components)
-- Full A11y Support
-- Pass custom actions to the modal to allow granular control of the experience.
+- A11y First
+- Built with `<FocusLock/>` from [react-focus-lock](https://github.com/theKashey/react-focus-lock)
+- Automatically returns focus to activating element when the modal is closed.
 
 #### [<ModalRelay\/>](https://github.com/freddiemixell/modal-relay/tree/main/src/components)
 - Uses React Portals to escape the react tree and render your modal above your application.
@@ -131,7 +43,9 @@ Docs for each component are co-located with the components. Check out the `/src`
 ## No CSS Included 🚫
 There isn't any css included in this library and that is intentional. All components will take `className` or style props making them perfect complements for libraries like styled-components or really any style system.
 
-You will find a bare bones css starter below. This will show you all the css classes that are available one the modal. Take these *ugly* styles and turn it into your own beautiful modal! 😃
+You will find a bare bones css starter below. This will show you all the css classes that are available on the modal. Take these *ugly* styles and turn it into your own beautiful modal! 😃
+
+If you're using Tailwinds take a look at the example repo to see how you can use the `tailwind` prop to get off the ground faster.
 
 ```css
 /* Modal dialog element */
@@ -164,6 +78,31 @@ You will find a bare bones css starter below. This will show you all the css cla
   z-index: 100;
 }
 ```
+
+## Common Mistakes
+There are two ways that you could mess this up right out of the box.
+
+1. You didn't create a portal element:
+  - You'll need access to the HTML markup where your React app is being rendered. If you're using something like Create React App that will be the `index.html` located within your `./public` folder. If you're not using CRA you will likely have to figure out how to modify the HTML template created by your build system. Most frameworks provide documentation about how to do this but if you're confused just open an issue! :)
+2. No ID Set At Modal Router Level:
+  - I think this is better to show an example of what works and what doesn't:
+
+##### Works
+```tsx
+<ModalRelay modalRoot={modalRoot}>
+  <YourCustomModal id="custom-modal-one"/>
+  <YourOtherModal id="other-modal"/>
+</ModalRelay>
+```
+
+##### Doesn't Work
+```tsx
+<ModalRelay modalRoot={modalRoot}>
+  <YourCustomModal/>
+  <YourOtherModal/>
+</ModalRelay>
+```
+Even if you pass an ID to the `<Modal/>` component within your custom modal, the `<ModalRelay/>` won't be able to detect it. A good rule of thumb is to create your ID as a variable and export it from your custom modal. Then when you want to activate that modal you just import that variable and pass it to `activate()` or `<ModalLink/>`.
 
 ## License
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -26,7 +26,7 @@
       }
     },
     "..": {
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "react-focus-lock": "^2.6.0",

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -14,6 +14,7 @@
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="stylesheet" href="https://unpkg.com/tailwindcss@2.2.19/dist/tailwind.min.css" />
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 
 import { ModalRelay } from 'modal-relay';
-import SettingsModal, { SETTINGS_MODAL_ID } from './components/SettingsModal';
+import SettingsModal, { SETTINGS_MODAL_ID } from './components/Modals/SettingsModal';
 import SomePage from './components/SomePage';
+import { EditProfileModal, EDIT_PROFILE_ID } from './components/Modals/EditProfileModal';
 
 const modalRoot = document.getElementById('modal-root');
 
@@ -13,6 +14,7 @@ const App = () => {
       <SomePage/>
       <ModalRelay modalRoot={modalRoot}>
         <SettingsModal id={SETTINGS_MODAL_ID} />
+        <EditProfileModal id={EDIT_PROFILE_ID} />
       </ModalRelay>
     </div>
   )

--- a/example/src/components/Modals/EditProfileModal.tsx
+++ b/example/src/components/Modals/EditProfileModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useModalStore, ModalMask, Modal, useEscapeHatch, ModalStore, ModalWindow, CloseIcon } from "modal-relay";
+import { useModalStore, ModalMask, Modal, ModalStore, ModalWindow, CloseIcon } from "modal-relay";
 
 type EditProfileModalProps = {
     id: string;
@@ -19,9 +19,6 @@ export const EditProfileModal = ({id}: EditProfileModalProps) => {
         // do some logic to save the profile.
         deactivate(id);
     }
-
-    // Callback function to handle escape key press.
-    useEscapeHatch(handleClose);
 
     return (
         <Modal

--- a/example/src/components/Modals/EditProfileModal.tsx
+++ b/example/src/components/Modals/EditProfileModal.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { useModalStore, ModalMask, Modal, useEscapeHatch, ModalStore, ModalWindow, CloseIcon } from "modal-relay";
+
+type EditProfileModalProps = {
+    id: string;
+}
+
+const selector = (state: ModalStore) => state.deactivate;
+
+export const EDIT_PROFILE_ID = "EDIT_PROFILE_ID";
+
+export const EditProfileModal = ({id}: EditProfileModalProps) => {
+    const deactivate = useModalStore(selector);
+
+    // Memo function since its a dependency of useEscapeHatch.
+    const handleClose = () => deactivate(id);
+
+    const handleAgree = () => {
+        // do some logic to save the profile.
+        deactivate(id);
+    }
+
+    // Callback function to handle escape key press.
+    useEscapeHatch(handleClose);
+
+    return (
+        <Modal
+            aria-labelledby="modal-title"
+            aria-describedby="modal-description"
+        >
+            <ModalWindow tailwind>
+                <div className="flex flex-col items-start p-4">
+                    <div className="flex items-center w-full">
+                        <h2 id="modal-title" className="text-gray-900 font-medium text-lg">
+                            Edit Profile
+                        </h2>
+                        <CloseIcon
+                            className="ml-auto"
+                            onClose={handleClose}
+                            tailwind
+                        />
+                    </div>
+                    <hr />
+                    <div id="modal-description">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+                    </div>
+                    <hr />
+                    <div className="ml-auto">
+                        <button
+                            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mr-2"
+                            onClick={handleAgree}
+                        >
+                            Agree
+                        </button>
+                        <button
+                            className="bg-transparent hover:bg-gray-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
+                            onClick={handleClose}
+                        >
+                            Close
+                        </button>
+                    </div>
+                </div>
+            </ModalWindow>
+            <ModalMask tailwind onClose={handleClose} />
+        </Modal>
+    );
+}

--- a/example/src/components/Modals/SettingsModal.tsx
+++ b/example/src/components/Modals/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, useModalStore } from 'modal-relay';
+import { Modal, ModalMask, ModalStore, useModalStore } from 'modal-relay';
 
 // Set the ID here because it needs to be available to the <ModalRelay/> component.
 type SettingsProps = {
@@ -13,26 +13,16 @@ function handleSubmit() {
 export const SETTINGS_MODAL_ID = 'settings';
 
 const SettingsModal = ({id}: SettingsProps) => {
-    const {deactivate} = useModalStore();
+    const deactivate = useModalStore((state: ModalStore) => state.deactivate);
     return (
         <Modal
-            id={id}
-            title="Settings"
-            actions={[
-                {
-                    label: 'Close',
-                    onClick: () => deactivate(id)
-                },
-                {
-                    label: 'Update',
-                    onClick: (e: React.FormEvent<HTMLFormElement>) => {
-                        e.preventDefault();
-                        handleSubmit();
-                    }
-                }
-            ]}
+            aria-labelledby="modal-title"
+            aria-describedby="modal-description"
         >
             <form onSubmit={handleSubmit}>
+                <div>
+                    <h2>Settings</h2>
+                </div>
                 <div>
                     <label htmlFor="firstName">First Name</label>
                     <input type="text" id="firstName" name="firstName"  />
@@ -41,7 +31,11 @@ const SettingsModal = ({id}: SettingsProps) => {
                     <label htmlFor="lastName">Last Name</label>
                     <input type="text" id="lastName" name="lastName"  />
                 </div>
+                <div>
+                    <button onClick={() => deactivate(id)}>Cancel</button>
+                </div>
             </form>
+            <ModalMask onClose={() => deactivate(id)}/>
         </Modal>
     )
 }

--- a/example/src/components/SomePage.tsx
+++ b/example/src/components/SomePage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ModalLink } from 'modal-relay';
-import { SETTINGS_MODAL_ID } from './SettingsModal';
+import { EDIT_PROFILE_ID } from './Modals/EditProfileModal';
+import { SETTINGS_MODAL_ID } from './Modals/SettingsModal';
 
 // You can use any HTMLButtonElement Props with the ModalLink component.
 const buttonStyle = {backgroundColor: '#333', color: 'white', border: 'none', borderRadius: '5em', padding: '10px 10px', fontWeight: 'bold'}
@@ -14,6 +15,9 @@ const SomePage = () => {
             <main>
                 <section>
                     <p>Some content</p>
+                    <ModalLink open={EDIT_PROFILE_ID} style={buttonStyle}>
+                        Edit Profile
+                    </ModalLink>
                     <ModalLink open={SETTINGS_MODAL_ID} style={buttonStyle}>
                         Edit Settings
                     </ModalLink>

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -12,29 +12,3 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
-
-.modal {
-  display: block;
-}
-
-.modal__window {
-  display: inline-block;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: #fff;
-  border: 2px solid black;
-  padding: 18px;
-  z-index: 101;
-}
-
-.modal__mask {
-  position: fixed;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 100;
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modal-relay",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Display modals from anywhere in your app easily. React Router not required!",
   "author": "freddiemixell",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modal-relay",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Display modals from anywhere in your app easily. React Router not required!",
   "author": "freddiemixell",
   "license": "MIT",

--- a/src/components/CloseIcon.tsx
+++ b/src/components/CloseIcon.tsx
@@ -1,35 +1,34 @@
 import * as React from 'react';
-
-
-type DefaultButtonProps = React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>
+import { DefaultButtonProps } from '../core/types';
 
 type CloseIconProps = {
-    onClose: () => void;
-    svgClassName?: string;
-    svgViewBox?: string;
-    tailwind?: boolean;
+  onClose: () => void;
+  svgClassName?: string;
+  svgViewBox?: string;
+  tailwind?: boolean;
 } & DefaultButtonProps;
 
-const TAILWIND_ICON_DEFAULT = "fill-current text-gray-700 w-6 h-6 cursor-pointer";
+const TAILWIND_ICON_DEFAULT =
+  'fill-current text-gray-700 w-6 h-6 cursor-pointer';
 
-export const CloseIcon = ({onClose, svgClassName = '', svgViewBox = '0 0 18 18', ...props}: CloseIconProps) => {
-    if (props.tailwind) {
-        svgClassName += ' ' + TAILWIND_ICON_DEFAULT;
-    }
-    return (
-        <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            {...props}
-        >
-            <svg
-                className={svgClassName}
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox={svgViewBox}
-            >
-                <path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z" />
-            </svg>
-        </button>
-    );
-}
+export const CloseIcon = ({
+  onClose,
+  svgClassName = '',
+  svgViewBox = '0 0 18 18',
+  ...props
+}: CloseIconProps) => {
+  if (props.tailwind) {
+    svgClassName += ' ' + TAILWIND_ICON_DEFAULT;
+  }
+  return (
+    <button type="button" onClick={onClose} aria-label="Close" {...props}>
+      <svg
+        className={svgClassName}
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox={svgViewBox}
+      >
+        <path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z" />
+      </svg>
+    </button>
+  );
+};

--- a/src/components/CloseIcon.tsx
+++ b/src/components/CloseIcon.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+
+
+type DefaultButtonProps = React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>
+
+type CloseIconProps = {
+    onClose: () => void;
+    svgClassName?: string;
+    svgViewBox?: string;
+    tailwind?: boolean;
+} & DefaultButtonProps;
+
+const TAILWIND_ICON_DEFAULT = "fill-current text-gray-700 w-6 h-6 cursor-pointer";
+
+export const CloseIcon = ({onClose, svgClassName = '', svgViewBox = '0 0 18 18', ...props}: CloseIconProps) => {
+    if (props.tailwind) {
+        svgClassName += ' ' + TAILWIND_ICON_DEFAULT;
+    }
+    return (
+        <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            {...props}
+        >
+            <svg
+                className={svgClassName}
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox={svgViewBox}
+            >
+                <path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z" />
+            </svg>
+        </button>
+    );
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,22 +1,13 @@
-import React from 'react'
-import FocusLock from 'react-focus-lock'
-
-type DefaultDivProps = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
->
+import React from 'react';
+import FocusLock from 'react-focus-lock';
+import { DefaultDivProps } from '../core/types';
 
 export const Modal = ({ children, ...props }: DefaultDivProps) => {
-    return (
-      <FocusLock returnFocus>
-        <div
-          className="modal"
-          role="dialog"
-          aria-modal="true"
-          {...props}
-        >
-          {children}
-        </div>
-      </FocusLock>
-    )
-  }
+  return (
+    <FocusLock returnFocus>
+      <div className="modal" role="dialog" aria-modal="true" {...props}>
+        {children}
+      </div>
+    </FocusLock>
+  );
+};

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,23 +1,32 @@
 import React from 'react'
 import FocusLock from 'react-focus-lock'
-import { ModalType, ModalStore } from '../core/types'
+import { ModalType, ModalStore, ActionButton } from '../core/types'
 import { useModalStore } from '../core/store'
+
+export { FocusLock }
+
+type DefaultDialogProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>
+
+type DefaultDivProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>
 
 const dialogProps = {
   className: 'modal',
   role: 'dialog',
   'aria-modal': 'true'
-} as React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
->
+} as DefaultDialogProps
 
 // Placing outside of the component to avoid re-rendering.
-const selector = (state: ModalStore) => state.deactivate;
+const selector = (state: ModalStore) => state.deactivate
 
 // Since only one modal can be active at a time, we can use a single ID for all modals.
-const titleId = 'modal-title';
-const descId = 'modal-desc';
+const titleId = 'modal-title'
+const descId = 'modal-desc'
 
 export const Modal = ({
   id,
@@ -52,31 +61,89 @@ export const Modal = ({
 
   return (
     <FocusLock returnFocus>
-      <div {...dialogProps}>
-        <div className="modal__window">
-          {(title || description) && (
-            <header className="modal__head">
-              {title && <h2 id={titleId}>{title}</h2>}
-              {description && <p id={descId}>{description}</p>}
-            </header>
-          )}
-          <div className="modal__content">{children}</div>
-          <footer className="modal__actions">
-            {actions.length > 0
-              ? actions.map((action) => (
-                  <button
-                    key={action.label}
-                    className="button button--primary"
-                    onClick={action.onClick}
-                  >
-                    {action.label}
-                  </button>
-                ))
-              : null}
-          </footer>
-        </div>
-        <div onClick={closeDialog} className="modal__mask" />
-      </div>
+      <Dialog>
+        <ModalWindow>
+          <ModalHeader>
+            {title && <h2 id={titleId}>{title}</h2>}
+            {description && <p id={descId}>{description}</p>}
+            <button onClick={() => deactivate(id)}>x</button>
+          </ModalHeader>
+          <ModalContent>{children}</ModalContent>
+          <Actions actions={actions} />
+        </ModalWindow>
+        <ModalMask onClose={closeDialog} />
+      </Dialog>
     </FocusLock>
+  )
+}
+
+export const Dialog = ({ children, ...props }: DefaultDialogProps) => {
+  return (
+    <div {...dialogProps} {...props}>
+      {children}
+    </div>
+  )
+}
+
+type ModalWindowProps = DefaultDivProps
+
+export const ModalWindow = ({ children, ...props }: ModalWindowProps) => {
+  return (
+    <div className='modal__window' {...props}>
+      {children}
+    </div>
+  )
+}
+
+type ModalContentProps = DefaultDivProps
+
+export const ModalContent = ({ children, ...props }: ModalContentProps) => {
+  return (
+    <div className='modal__content' {...props}>
+      {children}
+    </div>
+  )
+}
+
+type ModalMaskProps = { onClose: () => void }
+
+export const ModalMask = ({
+  onClose,
+  ...props
+}: ModalMaskProps & DefaultDivProps) => {
+  return <div onClick={onClose} className='modal__mask' {...props} />
+}
+
+type ModalHeaderProps = DefaultDivProps
+
+export const ModalHeader = ({ children, ...props }: ModalHeaderProps) => {
+  return (
+    <header className='modal__head' {...props}>
+      {children}
+    </header>
+  )
+}
+
+type ActionsProps = { actions: ActionButton[] }
+
+export const Actions = ({
+  actions,
+  ...props
+}: ActionsProps & DefaultDivProps) => {
+  if (actions.length === 0) {
+    return null
+  }
+  return (
+    <footer className='modal__actions' {...props}>
+      {actions.map((action) => (
+        <button
+          key={action.label}
+          className='button button--primary'
+          onClick={action.onClick}
+        >
+          {action.label}
+        </button>
+      ))}
+    </footer>
   )
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,149 +1,22 @@
 import React from 'react'
 import FocusLock from 'react-focus-lock'
-import { ModalType, ModalStore, ActionButton } from '../core/types'
-import { useModalStore } from '../core/store'
-
-export { FocusLock }
-
-type DefaultDialogProps = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
->
 
 type DefaultDivProps = React.DetailedHTMLProps<
   React.HTMLAttributes<HTMLDivElement>,
   HTMLDivElement
 >
 
-const dialogProps = {
-  className: 'modal',
-  role: 'dialog',
-  'aria-modal': 'true'
-} as DefaultDialogProps
-
-// Placing outside of the component to avoid re-rendering.
-const selector = (state: ModalStore) => state.deactivate
-
-// Since only one modal can be active at a time, we can use a single ID for all modals.
-const titleId = 'modal-title'
-const descId = 'modal-desc'
-
-export const Modal = ({
-  id,
-  children,
-  title,
-  description,
-  actions = []
-}: ModalType) => {
-  const deactivate = useModalStore(selector)
-
-  // Using useCallback because this is a dependency of useEffect which would cause re-rendering.
-  const closeDialog = React.useCallback(() => deactivate(id), [])
-
-  if (title) {
-    dialogProps['aria-labelledby'] = titleId
-  }
-
-  if (description) {
-    dialogProps['aria-describedby'] = descId
-  }
-
-  // Allow users to close the modal with ESC key.
-  React.useEffect(() => {
-    const close = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        closeDialog()
-      }
-    }
-    document.addEventListener('keydown', close)
-    return () => document.removeEventListener('keydown', close)
-  }, [closeDialog])
-
-  return (
-    <FocusLock returnFocus>
-      <Dialog>
-        <ModalWindow>
-          <ModalHeader>
-            {title && <h2 id={titleId}>{title}</h2>}
-            {description && <p id={descId}>{description}</p>}
-            <button onClick={() => deactivate(id)}>x</button>
-          </ModalHeader>
-          <ModalContent>{children}</ModalContent>
-          <Actions actions={actions} />
-        </ModalWindow>
-        <ModalMask onClose={closeDialog} />
-      </Dialog>
-    </FocusLock>
-  )
-}
-
-export const Dialog = ({ children, ...props }: DefaultDialogProps) => {
-  return (
-    <div {...dialogProps} {...props}>
-      {children}
-    </div>
-  )
-}
-
-type ModalWindowProps = DefaultDivProps
-
-export const ModalWindow = ({ children, ...props }: ModalWindowProps) => {
-  return (
-    <div className='modal__window' {...props}>
-      {children}
-    </div>
-  )
-}
-
-type ModalContentProps = DefaultDivProps
-
-export const ModalContent = ({ children, ...props }: ModalContentProps) => {
-  return (
-    <div className='modal__content' {...props}>
-      {children}
-    </div>
-  )
-}
-
-type ModalMaskProps = { onClose: () => void }
-
-export const ModalMask = ({
-  onClose,
-  ...props
-}: ModalMaskProps & DefaultDivProps) => {
-  return <div onClick={onClose} className='modal__mask' {...props} />
-}
-
-type ModalHeaderProps = DefaultDivProps
-
-export const ModalHeader = ({ children, ...props }: ModalHeaderProps) => {
-  return (
-    <header className='modal__head' {...props}>
-      {children}
-    </header>
-  )
-}
-
-type ActionsProps = { actions: ActionButton[] }
-
-export const Actions = ({
-  actions,
-  ...props
-}: ActionsProps & DefaultDivProps) => {
-  if (actions.length === 0) {
-    return null
-  }
-  return (
-    <footer className='modal__actions' {...props}>
-      {actions.map((action) => (
-        <button
-          key={action.label}
-          className='button button--primary'
-          onClick={action.onClick}
+export const Modal = ({ children, ...props }: DefaultDivProps) => {
+    return (
+      <FocusLock returnFocus>
+        <div
+          className="modal"
+          role="dialog"
+          aria-modal="true"
+          {...props}
         >
-          {action.label}
-        </button>
-      ))}
-    </footer>
-  )
-}
+          {children}
+        </div>
+      </FocusLock>
+    )
+  }

--- a/src/components/ModalLink.tsx
+++ b/src/components/ModalLink.tsx
@@ -1,27 +1,19 @@
-import React from 'react'
-import { useModalStore } from '../core/store'
-import { ModalStore } from '../core/types'
+import React from 'react';
+import { useModalStore } from '../core/store';
+import { ModalStore, DefaultButtonProps } from '../core/types';
 
 type ModalLinkProps = {
-  children: JSX.Element | JSX.Element[] | string
-  open: string
-}
+  children: JSX.Element | JSX.Element[] | string;
+  open: string;
+} & DefaultButtonProps;
 
-const selector = (state: ModalStore) => state.activate
+const selector = (state: ModalStore) => state.activate;
 
-export const ModalLink = ({
-  children,
-  open,
-  ...props
-}: ModalLinkProps &
-  React.DetailedHTMLProps<
-    React.HTMLAttributes<HTMLButtonElement>,
-    HTMLButtonElement
-  >) => {
-  const activate = useModalStore(selector)
+export const ModalLink = ({ children, open, ...props }: ModalLinkProps) => {
+  const activate = useModalStore(selector);
   return (
-    <button type='button' onClick={() => activate(open)} {...props}>
+    <button type="button" onClick={() => activate(open)} {...props}>
       {children}
     </button>
-  )
-}
+  );
+};

--- a/src/components/ModalMask.tsx
+++ b/src/components/ModalMask.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react'
+
+type DefaultDivProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>
+
+type ModalMaskProps = { onClose: () => void, tailwind?: boolean } & DefaultDivProps
+
+const TAILWIND_MASK_DEFAULT = 'fixed top-0 left-0 h-full w-full z-40 bg-gray-800 bg-opacity-95';
+
+export const ModalMask = ({
+  onClose,
+  className = '',
+  ...props
+}: ModalMaskProps) => {
+  if (props.tailwind) {
+    className += ' ' + TAILWIND_MASK_DEFAULT;
+  }
+  return <div onClick={onClose} className={`modal__mask ${className}`} {...props} />
+}

--- a/src/components/ModalMask.tsx
+++ b/src/components/ModalMask.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react'
+import * as React from 'react';
+import { DefaultDivProps } from '../core/types';
 
-type DefaultDivProps = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
->
+type ModalMaskProps = {
+  onClose: () => void;
+  tailwind?: boolean;
+} & DefaultDivProps;
 
-type ModalMaskProps = { onClose: () => void, tailwind?: boolean } & DefaultDivProps
-
-const TAILWIND_MASK_DEFAULT = 'fixed top-0 left-0 h-full w-full z-40 bg-gray-800 bg-opacity-95';
+const TAILWIND_MASK_DEFAULT =
+  'fixed top-0 left-0 h-full w-full z-40 bg-gray-800 bg-opacity-95';
 
 export const ModalMask = ({
   onClose,
@@ -17,5 +17,7 @@ export const ModalMask = ({
   if (props.tailwind) {
     className += ' ' + TAILWIND_MASK_DEFAULT;
   }
-  return <div onClick={onClose} className={`modal__mask ${className}`} {...props} />
-}
+  return (
+    <div onClick={onClose} className={`modal__mask ${className}`} {...props} />
+  );
+};

--- a/src/components/ModalMask.tsx
+++ b/src/components/ModalMask.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DefaultDivProps } from '../core/types';
+import { useEscapeHatch } from '../core/helpers';
 
 type ModalMaskProps = {
   onClose: () => void;
@@ -17,6 +18,7 @@ export const ModalMask = ({
   if (props.tailwind) {
     className += ' ' + TAILWIND_MASK_DEFAULT;
   }
+  useEscapeHatch(onClose);
   return (
     <div onClick={onClose} className={`modal__mask ${className}`} {...props} />
   );

--- a/src/components/ModalRelay.tsx
+++ b/src/components/ModalRelay.tsx
@@ -1,24 +1,24 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import { useModalStore } from '../core/store'
-import { ModalRelayProps, ModalStore } from '../core/types'
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { useModalStore } from '../core/store';
+import { ModalRelayProps, ModalStore } from '../core/types';
 
-const selector = (state: ModalStore) => state.modals
+const selector = (state: ModalStore) => state.modals;
 
 // This can be placed anywhere in app because it uses a portal.
 export const ModalRelay = ({ children, modalRoot }: ModalRelayProps) => {
-  const modals = useModalStore(selector)
+  const modals = useModalStore(selector);
   const filteredModals = React.Children.toArray(children).filter(
     (child) => React.isValidElement(child) && modals.includes(child.props?.id)
-  )
+  );
 
   // Destructure the first modal so we only ever show one at a time.
-  const [firstModal = null] = filteredModals
+  const [firstModal = null] = filteredModals;
 
   return modalRoot
     ? ReactDOM.createPortal(
         <React.Fragment>{firstModal}</React.Fragment>,
         modalRoot
       )
-    : null
-}
+    : null;
+};

--- a/src/components/ModalWindow.tsx
+++ b/src/components/ModalWindow.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+type DefaultDivProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>
+
+type ModalWindowProps = { tailwind?: boolean } & DefaultDivProps
+
+const TAILWIND_WINDOW_DEFAULT = "bg-white rounded-lg w-1/2 inline-block fixed left-2/4 top-1/2 z-50";
+
+export const ModalWindow = ({className, style, children, ...props}: ModalWindowProps) => {
+    if (props.tailwind) {
+        className += " " + TAILWIND_WINDOW_DEFAULT;
+        style = {...style, ...{transform: "translate(-50%, -50%)"}}
+    }
+    return (
+        <div className={`modal__window ${className}`} style={style} {...props}>
+            {children}
+        </div>
+    );
+}

--- a/src/components/ModalWindow.tsx
+++ b/src/components/ModalWindow.tsx
@@ -4,20 +4,18 @@ import { DefaultDivProps } from '../core/types';
 type ModalWindowProps = { tailwind?: boolean } & DefaultDivProps;
 
 const TAILWIND_WINDOW_DEFAULT =
-  'bg-white rounded-lg w-1/2 inline-block fixed left-2/4 top-1/2 z-50';
+  'bg-white rounded-lg w-1/2 inline-block fixed left-2/4 top-1/2 z-50 transform -translate-x-1/2 -translate-y-1/2';
 
 export const ModalWindow = ({
   className,
-  style,
   children,
   ...props
 }: ModalWindowProps) => {
   if (props.tailwind) {
     className += ' ' + TAILWIND_WINDOW_DEFAULT;
-    style = { ...style, ...{ transform: 'translate(-50%, -50%)' } };
   }
   return (
-    <div className={`modal__window ${className}`} style={style} {...props}>
+    <div className={`modal__window ${className}`} {...props}>
       {children}
     </div>
   );

--- a/src/components/ModalWindow.tsx
+++ b/src/components/ModalWindow.tsx
@@ -1,22 +1,24 @@
 import * as React from 'react';
+import { DefaultDivProps } from '../core/types';
 
-type DefaultDivProps = React.DetailedHTMLProps<
-  React.HTMLAttributes<HTMLDivElement>,
-  HTMLDivElement
->
+type ModalWindowProps = { tailwind?: boolean } & DefaultDivProps;
 
-type ModalWindowProps = { tailwind?: boolean } & DefaultDivProps
+const TAILWIND_WINDOW_DEFAULT =
+  'bg-white rounded-lg w-1/2 inline-block fixed left-2/4 top-1/2 z-50';
 
-const TAILWIND_WINDOW_DEFAULT = "bg-white rounded-lg w-1/2 inline-block fixed left-2/4 top-1/2 z-50";
-
-export const ModalWindow = ({className, style, children, ...props}: ModalWindowProps) => {
-    if (props.tailwind) {
-        className += " " + TAILWIND_WINDOW_DEFAULT;
-        style = {...style, ...{transform: "translate(-50%, -50%)"}}
-    }
-    return (
-        <div className={`modal__window ${className}`} style={style} {...props}>
-            {children}
-        </div>
-    );
-}
+export const ModalWindow = ({
+  className,
+  style,
+  children,
+  ...props
+}: ModalWindowProps) => {
+  if (props.tailwind) {
+    className += ' ' + TAILWIND_WINDOW_DEFAULT;
+    style = { ...style, ...{ transform: 'translate(-50%, -50%)' } };
+  }
+  return (
+    <div className={`modal__window ${className}`} style={style} {...props}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,87 +1,94 @@
 # Components
 
 ## Modal
+This is the basic building block of an accessible modal element. By default it includes all props you'll need for a11y support except for `aria-labelledby` and `aria-describedby`. All modals should be built with this as the outer wrapper.
 
-This is an A11y first modal. No stylesheet is included by this module so that you can fully utilize whatever system you're using. A full list of css classes can be seen below to style however you'd like.
+- A11y First
+- Built with `<FocusLock/>` from [react-focus-lock](https://github.com/theKashey/react-focus-lock)
+- Automatically returns focus to activating element when the modal is closed.
 
 **Props:**
 
-- id: `String`
-- children: `JSX.Element | JSX.Element[]`
-- title: `String`
-- description: `String`
-- actions: `Array<{label: `String`, onClick: `Function`}>`
+- `HTMLDivElement` props.
+- `aria-labelledby` String - this is the id for the title element.
+- `aria-describedby` String - this is the id for the content element.
 
 ### Example
 
-Styled Components
+```jsx
+<Modal
+  aria-labelledby="modal-title"
+  aria-describedby="modal-description"
+>
+... your component
+</Modal>
+```
+
+## ModalWindow
+This is a helper simply to describe the basic building blocks all modals should follow in this system. The window also has built in Tailwind css support for quick integration. Also includes a default class of `modal__window` for styling.
+
+**Props:**
+
+- `HTMLDivElement` props.
+- `tailwind` Boolean (optional)
+
+### Example w/Tailwind
 
 ```jsx
-  import styled from "styled-components";
-  import { Modal, useModalStore } from "modal-relay";
+<Modal
+  aria-labelledby="modal-title"
+  aria-describedby="modal-description"
+>
+  <ModalWindow tailwind>
+  ... your component
+  </ModalWindow>
+</Modal>
+```
 
-  const StyledModal = styled.(Modal)`
-      display: block;
+## ModalMask
+This is another building block component that all modals should utilize by default. If you don't use this component you should create one in your system. Having a background that allows users to exit on click is essential to usability with your modals.
 
-      /* Inside the modal */
-      .modal__window {
-          display: inline-block;
-          position: fixed;
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-          background: #fff;
-          border: 2px solid black;
-          padding: 18px;
-          z-index: 101;
-      }
+By default this modal mask will allow users to click outside of the modal to exit with its `onClose` prop. This same `onClose` prop will be used to listen for the `Escape` key press. When that happens it will automatically run the `onClose` logic.
 
+**Props:**
 
-      /* Element Behind The Modal */
-      .modal__mask {
-          position: fixed;
-          top: 0;
-          left: 0;
-          height: 100%;
-          width: 100%;
-          background: rgba(0, 0, 0, 0.5);
-          z-index: 100;
-      }
-  `;
+- `HTMLDivElement` props.
+- `tailwind` Boolean (optional)
+- `onClose` () => void The method to run on modal close.
 
-  type ModalSettingsProps = {
-      id: string;
-  }
+### Example w/Tailwind
 
-  export default function SettingsModal(({id}): ModalSettingsProps) {
-      let {deactivate} = useModalStore();
-      const handleUpdate = () => {
-          console.log('Updated Settings');
-          deactivate(id);
-      }
-      return (
-          <StyledModal
-              id={id}
-              title="Settings"
-              description="Update your app settings."
-              action=[
-                  {
-                      onClick: () => deactivate(id),
-                      label: "Cancel"
-                  },
-                  {
-                      onClick: handleUpdate,
-                      label: "Update Settings"
-                  }
-              ]
-          >
-              <div>
-                  <label htmlFor="dark-mode">Dark Mode</label>
-                  <input id="dark-mode" type="checkbox"/>
-              </div>
-          </StyledModal>
-      );
-  }
+```jsx
+<Modal>
+  <ModalWindow tailwind>
+  ... your component
+  </ModalWindow>
+  <ModalMask tailwind onClose={handleClose} />
+</Modal>
+```
+
+## CloseIcon
+This is yet another building block component that is met more or less as an example of how you should create your close Icon. That doesn't mean you shouldn't use it because this is the a11y friendly way to create a close icon.
+
+- Adds proper aria close label.
+- Wrapped with a button so it's available for tab navigation.
+
+**Props:**
+
+- `HTMLDivElement` props.
+- `onClose`: Function
+- `svgClassName`: String (Optional)
+- `svgViewBox`: String (Optional)
+- `tailwind`: Boolean (Optional)
+
+### Example w/Tailwind
+
+```jsx
+<CloseIcon
+  className="ml-auto"
+  onClose={handleClose}
+  tailwind
+/>
 ```
 
 ## ModalRelay

--- a/src/components/README.md
+++ b/src/components/README.md
@@ -1,9 +1,11 @@
 # Components
 
 ## Modal
+
 This is an A11y first modal. No stylesheet is included by this module so that you can fully utilize whatever system you're using. A full list of css classes can be seen below to style however you'd like.
 
 **Props:**
+
 - id: `String`
 - children: `JSX.Element | JSX.Element[]`
 - title: `String`
@@ -13,78 +15,81 @@ This is an A11y first modal. No stylesheet is included by this module so that yo
 ### Example
 
 Styled Components
-  ```jsx
-    import styled from "styled-components";
-    import { Modal, useModalStore } from "modal-relay";
 
-    const StyledModal = styled.(Modal)`
-        display: block;
+```jsx
+  import styled from "styled-components";
+  import { Modal, useModalStore } from "modal-relay";
 
-        /* Inside the modal */
-        .modal__window {
-            display: inline-block;
-            position: fixed;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            background: #fff;
-            border: 2px solid black;
-            padding: 18px;
-            z-index: 101;
-        }
+  const StyledModal = styled.(Modal)`
+      display: block;
+
+      /* Inside the modal */
+      .modal__window {
+          display: inline-block;
+          position: fixed;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          background: #fff;
+          border: 2px solid black;
+          padding: 18px;
+          z-index: 101;
+      }
 
 
-        /* Element Behind The Modal */
-        .modal__mask {
-            position: fixed;
-            top: 0;
-            left: 0;
-            height: 100%;
-            width: 100%;
-            background: rgba(0, 0, 0, 0.5);
-            z-index: 100;
-        }
-    `;
+      /* Element Behind The Modal */
+      .modal__mask {
+          position: fixed;
+          top: 0;
+          left: 0;
+          height: 100%;
+          width: 100%;
+          background: rgba(0, 0, 0, 0.5);
+          z-index: 100;
+      }
+  `;
 
-    type ModalSettingsProps = {
-        id: string;
-    }
+  type ModalSettingsProps = {
+      id: string;
+  }
 
-    export default function SettingsModal(({id}): ModalSettingsProps) {
-        let {deactivate} = useModalStore();
-        const handleUpdate = () => {
-            console.log('Updated Settings');
-            deactivate(id);
-        }
-        return (
-            <StyledModal
-                id={id}
-                title="Settings"
-                description="Update your app settings."
-                action=[
-                    {
-                        onClick: () => deactivate(id),
-                        label: "Cancel"
-                    },
-                    {
-                        onClick: handleUpdate,
-                        label: "Update Settings"
-                    }
-                ]
-            >
-                <div>
-                    <label htmlFor="dark-mode">Dark Mode</label>
-                    <input id="dark-mode" type="checkbox"/>
-                </div>
-            </StyledModal>
-        );
-    }
-  ```
+  export default function SettingsModal(({id}): ModalSettingsProps) {
+      let {deactivate} = useModalStore();
+      const handleUpdate = () => {
+          console.log('Updated Settings');
+          deactivate(id);
+      }
+      return (
+          <StyledModal
+              id={id}
+              title="Settings"
+              description="Update your app settings."
+              action=[
+                  {
+                      onClick: () => deactivate(id),
+                      label: "Cancel"
+                  },
+                  {
+                      onClick: handleUpdate,
+                      label: "Update Settings"
+                  }
+              ]
+          >
+              <div>
+                  <label htmlFor="dark-mode">Dark Mode</label>
+                  <input id="dark-mode" type="checkbox"/>
+              </div>
+          </StyledModal>
+      );
+  }
+```
 
 ## ModalRelay
+
 This component holds and displays your modals whenever you call them with a `<ModalLink/>` or the `const {activate} = useModalStore()` activate hook. The ModalRelay component will also create a portal with the provided dom node so you can have a uniform location in the dom to display any type of overlay. The children of this component should be anything that you want to relay over your application. The only requirement is an ID prop set on each child. This allows full flexibility to relay any type of message with whatever style system you're using. Make sure you create a modal root element in your html template if you haven't already. This should ideally be above or below the react app root. You'll want to add something like this: `<div id="modal-root"></div>`
 
 **Props:**
+
 - modalRoot: `HTMLElement`
 - children: `JSX.Element | JSX.Element[]`
 
@@ -92,52 +97,52 @@ This component holds and displays your modals whenever you call them with a `<Mo
 
 ```jsx
 // app.js
-import { ModalRelay } from "modal-relay";
-import SettingsModal from "../path/to/your/modal/SettingsModal";
+import { ModalRelay } from 'modal-relay';
+import SettingsModal from '../path/to/your/modal/SettingsModal';
 
-const modalRoot = document.getElementById("modal-root");
+const modalRoot = document.getElementById('modal-root');
 
 function Modals() {
-    return (
-        <ModalRelay modalRoot={modalRoot}>
-            <SettingsModal id="settings"/>
-        </ModalRelay>
-    );
+  return (
+    <ModalRelay modalRoot={modalRoot}>
+      <SettingsModal id="settings" />
+    </ModalRelay>
+  );
 }
 
 export default function App() {
   return (
     <>
-        <div className="App">
-            <h1>Hello world</h1>
-            <h2>This is your app!</h2>
-        </div>
-        <Modals/>
+      <div className="App">
+        <h1>Hello world</h1>
+        <h2>This is your app!</h2>
+      </div>
+      <Modals />
     </>
   );
 }
 ```
 
 ## ModalLink
-This component can take any HTMLButtonElement props so you can adapt it to whatever style system you're using. Pass the open prop the id of the modal you want to open. From the example above you'll see we can open the settings modal with the example code below. 
+
+This component can take any HTMLButtonElement props so you can adapt it to whatever style system you're using. Pass the open prop the id of the modal you want to open. From the example above you'll see we can open the settings modal with the example code below.
 
 **Props:**
+
 - open: `String` the id of the the modal to open.
 - children: `JSX.Element | JSX.Element[] | string`
 
 ### Example
 
 ```jsx
-import { ModalLink } from "modal-relay";
+import { ModalLink } from 'modal-relay';
 
 export default function SomePage() {
-    return (
-        <div>
-            <h1>Some page in your app</h1>
-            <ModalLink open="settings">
-                Edit Settings
-            </ModalLink>
-        </div>
-    );
+  return (
+    <div>
+      <h1>Some page in your app</h1>
+      <ModalLink open="settings">Edit Settings</ModalLink>
+    </div>
+  );
 }
 ```

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -20,3 +20,20 @@ export default function SomePage() {
     );
 }
 ```
+
+## useEscapeHatch
+
+This hook will allow you to pass your onClose handler to trigger on keyboard escape key press. If you're using the `<ModalMask/>` component you don't need to use that component will attach the listener for you. 
+
+```jsx
+import { useEscapeHatch, useModalStore } from "modal-relay";
+
+function MyModal({id}) {
+    const {deactivate} = useModalStore();
+    const onClose = () => deactivate(id);
+
+    useEscapeHatch(onClose);
+
+    ...component stuff
+}
+```

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,6 +1,7 @@
 # Core
 
 ## useModalStore
+
 This hook is a global store that allows you to add and remove modals from the `<ModalRelay/>` component. This is using the [zustand](https://github.com/pmndrs/zustand) library under the hood so it can be accessed from anywhere in your application. You can also pass a selector to `useModalStore` to optimize it for re-renders.
 
 ```jsx
@@ -19,4 +20,3 @@ export default function SomePage() {
     );
 }
 ```
-

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
 export const useEscapeHatch = (onCloseCallback: () => void) => {
-    return React.useEffect(() => {
-        const close = (e: KeyboardEvent) => {
-          if (e.key === 'Escape') {
-            onCloseCallback()
-          }
-        }
-        document.addEventListener('keydown', close)
-        return () => document.removeEventListener('keydown', close)
-    }, [])
-}
+  return React.useEffect(() => {
+    const close = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onCloseCallback();
+      }
+    };
+    document.addEventListener('keydown', close);
+    return () => document.removeEventListener('keydown', close);
+  }, []);
+};

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+export const useEscapeHatch = (onCloseCallback: () => void) => {
+    return React.useEffect(() => {
+        const close = (e: KeyboardEvent) => {
+          if (e.key === 'Escape') {
+            onCloseCallback()
+          }
+        }
+        document.addEventListener('keydown', close)
+        return () => document.removeEventListener('keydown', close)
+    }, [])
+}

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,5 +1,5 @@
-import create from 'zustand'
-import { ModalStore } from './types'
+import create from 'zustand';
+import { ModalStore } from './types';
 
 export const useModalStore = create<ModalStore>((set) => ({
   modals: [],
@@ -7,12 +7,12 @@ export const useModalStore = create<ModalStore>((set) => ({
     set((state) => ({
       ...state,
       modals: [...state.modals, id]
-    }))
+    }));
   },
   deactivate: (id: string) => {
     set((state) => ({
       ...state,
       modals: state.modals.filter((m) => m !== id)
-    }))
+    }));
   }
-}))
+}));

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,10 +1,20 @@
 export interface ModalRelayProps {
-  children: JSX.Element | JSX.Element[]
-  modalRoot: HTMLElement | null
+  children: JSX.Element | JSX.Element[];
+  modalRoot: HTMLElement | null;
 }
 
 export interface ModalStore {
-  modals: string[]
-  activate: (id: string) => void
-  deactivate: (id: string) => void
+  modals: string[];
+  activate: (id: string) => void;
+  deactivate: (id: string) => void;
 }
+
+export type DefaultDivProps = React.DetailedHTMLProps<
+  React.HTMLAttributes<HTMLDivElement>,
+  HTMLDivElement
+>;
+
+export type DefaultButtonProps = React.DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,13 +1,3 @@
-export type ActionButton = { label: string; onClick: (e?: any) => void }
-
-export interface ModalType {
-  id: string
-  children: JSX.Element | JSX.Element[]
-  title?: string
-  description?: string
-  actions?: ActionButton[]
-}
-
 export interface ModalRelayProps {
   children: JSX.Element | JSX.Element[]
   modalRoot: HTMLElement | null

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,4 @@
-type ActionButton = { label: string; onClick: (e?: any) => void }
+export type ActionButton = { label: string; onClick: (e?: any) => void }
 
 export interface ModalType {
   id: string

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,7 +1,7 @@
-import { ModalRelay } from '.'
+import { ModalRelay } from '.';
 
 describe('ExampleComponent', () => {
   it('is truthy', () => {
-    expect(ModalRelay).toBeTruthy()
-  })
-})
+    expect(ModalRelay).toBeTruthy();
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,25 @@
-import { Modal } from './components/Modal'
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalWindow,
+  ModalMask,
+  Dialog,
+  FocusLock
+} from './components/Modal'
 import { ModalRelay } from './components/ModalRelay'
 import { ModalLink } from './components/ModalLink'
 import { useModalStore } from './core/store'
 
-export { Modal, ModalRelay, ModalLink, useModalStore }
+export {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalWindow,
+  ModalMask,
+  Dialog,
+  FocusLock,
+  ModalRelay,
+  ModalLink,
+  useModalStore
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,15 +1,15 @@
-import { ModalRelay } from './components/ModalRelay'
-import { ModalLink } from './components/ModalLink'
-import { Modal } from './components/Modal'
-import { ModalMask } from './components/ModalMask'
-import { ModalWindow } from './components/ModalWindow'
-import { CloseIcon } from './components/CloseIcon'
-import { useModalStore } from './core/store'
-import { useEscapeHatch } from './core/helpers'
-import { ModalStore as MStore } from './core/types'
+import { ModalRelay } from './components/ModalRelay';
+import { ModalLink } from './components/ModalLink';
+import { Modal } from './components/Modal';
+import { ModalMask } from './components/ModalMask';
+import { ModalWindow } from './components/ModalWindow';
+import { CloseIcon } from './components/CloseIcon';
+import { useModalStore } from './core/store';
+import { useEscapeHatch } from './core/helpers';
+import { ModalStore as MStore } from './core/types';
 
 // Types
-export type ModalStore = MStore
+export type ModalStore = MStore;
 
 export {
   ModalMask,
@@ -19,5 +19,5 @@ export {
   ModalRelay,
   ModalLink,
   useModalStore,
-  useEscapeHatch,
-}
+  useEscapeHatch
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,25 +1,23 @@
-import {
-  Modal,
-  ModalContent,
-  ModalHeader,
-  ModalWindow,
-  ModalMask,
-  Dialog,
-  FocusLock
-} from './components/Modal'
 import { ModalRelay } from './components/ModalRelay'
 import { ModalLink } from './components/ModalLink'
+import { Modal } from './components/Modal'
+import { ModalMask } from './components/ModalMask'
+import { ModalWindow } from './components/ModalWindow'
+import { CloseIcon } from './components/CloseIcon'
 import { useModalStore } from './core/store'
+import { useEscapeHatch } from './core/helpers'
+import { ModalStore as MStore } from './core/types'
+
+// Types
+export type ModalStore = MStore
 
 export {
-  Modal,
-  ModalContent,
-  ModalHeader,
-  ModalWindow,
   ModalMask,
-  Dialog,
-  FocusLock,
+  Modal,
+  ModalWindow,
+  CloseIcon,
   ModalRelay,
   ModalLink,
-  useModalStore
+  useModalStore,
+  useEscapeHatch,
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -6,12 +6,3 @@ declare module '*.css' {
   const content: { [className: string]: string };
   export default content;
 }
-
-interface SvgrComponent extends React.StatelessComponent<React.SVGAttributes<SVGElement>> {}
-
-declare module '*.svg' {
-  const svgUrl: string;
-  const svgComponent: SvgrComponent;
-  export default svgUrl;
-  export { svgComponent as ReactComponent }
-}


### PR DESCRIPTION
### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you updated the documentation?

### Explanation of Change
- Creates a more flexible and buildable Modal component and complementary elements that allow use in any design system.
- Adds partial support for tailwinds with `<ModalMask tailwind/>, <ModalWindow tailwind/>, and <CloseIcon tailwind/>`
- Built with A11y as the first priority which includes giving flexibility so no one ever needs to make the modals less accessible.  All modals should by default use the `<Modal aria-labelledby="your-title-id" aria-describedby="id-for-content"/> and <ModalMask onClose={yourCloseHandler}/>`. These are the basic a11y building blocks that every modal on the web should follow. (At least this is the vision I'm moving toward PR's welcome!)